### PR TITLE
Making sure that the password value is encrypted.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/openshift/Server.java
+++ b/src/main/java/org/jenkinsci/plugins/openshift/Server.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.openshift;
 
+import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -10,6 +11,7 @@ public class Server {
 	private String brokerAddress;
 	private String username;
 	private String password;
+	private Secret secret;
 
 	
 	@DataBoundConstructor
@@ -18,7 +20,8 @@ public class Server {
 		this.name = name;
 		this.brokerAddress = brokerAddress;
 		this.username = username;
-		this.password = password;
+		if (secret == null) secret = Secret.fromString(password);
+		this.password = secret.getEncryptedValue();
 	}
 
 	public String getName() {
@@ -34,6 +37,6 @@ public class Server {
 	}
 
 	public String getPassword() {
-		return password;
+		return Secret.toString(secret);
 	}
 }


### PR DESCRIPTION
In the past the OpenShift password Configuration was stored in plain text on the server side. This value is now encrypted.

 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <org.jenkinsci.plugins.openshift.DeployApplication_-DeployApplicationDescriptor plugin="openshift-deployer@1.1.2-SNAPSHOT">
   <DEFAULT__PUBLICKEY__PATH>/home/jenkins/.ssh/id_rsa.pub</DEFAULT__PUBLICKEY__PATH>
   <servers>
     <org.jenkinsci.plugins.openshift.Server>
       <name>OpenShift Online</name>
       <brokerAddress>openshift.redhat.com</brokerAddress>
       <username>jhoffmann@redhat.com</username>
       <password>lXldj2n60i9Wq9f7M0CRDmYMEKhu9zST5FOzJo/Tnfw=</password>
       <secret>lXldj2n60i9Wq9f7M0CRDmYMEKhu9zST5FOzJo/Tnfw=</secret>
     </org.jenkinsci.plugins.openshift.Server>
   </servers>
   <publicKeyPath>/home/jenkins/.ssh/id_rsa.pub</publicKeyPath>
 </org.jenkinsci.plugins.openshift.DeployApplication_-DeployApplicationDescriptor>
 ```

 For the encryption of the token I used hudson.util.Secret which seemed easier than the researched jasypt,
 because it handles cases in which a string is already encrypted better. Since we are using the DataBoundConstructor
 with little to no control over how a string is created and when, hence the internal checking of hudson.util.Secret seemed compelling although less secure.