### PR TITLE
[JENKINS-66315] Prepare OpenShift Deployer for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/src/main/java/org/jenkinsci/plugins/openshift/util/Logger.java
+++ b/src/main/java/org/jenkinsci/plugins/openshift/util/Logger.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.openshift.util;
 
 import java.io.OutputStream;
 
-import com.google.common.io.NullOutputStream;
+import org.apache.commons.io.output.NullOutputStream;
 
 /**
  * @author Siamak Sadeghianfar <ssadeghi@redhat.com>


### PR DESCRIPTION
Downstream of #13. See [JENKINS-66315](https://issues.jenkins.io/browse/JENKINS-66315) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.io.NullOutputStream` class, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/io/NullOutputStream.html) but was removed in Guava 15.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR migrates from `com.google.common.io.NullOutputStream` to [`org.apache.commons.io.output.NullOutputStream`](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/output/NullOutputStream.html), which is provided by Jenkins core via Apache Commons IO.

CC @siamaksade